### PR TITLE
feat: mq update january 29 2026

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 "use strict"
 
-const LV_CAP = 305;
+const LV_CAP = 315;
 
 const HIGHEST_PROF = 280;
 const HIGHEST_ARM_POT = 54;
@@ -8,7 +8,7 @@ const HIGHEST_WPN_POT = 55;
 const ARMOR_DIFFICULTY = 265;
 const WEAPON_DIFFICULTY = 300;
 const PRIMARY_STAT = 510;
-const SECONDARY_STAT = 277;
+const SECONDARY_STAT = 297;
 
 const range = function (begin, end, step=1) {
     let list = [];

--- a/js/xp.js
+++ b/js/xp.js
@@ -148,6 +148,9 @@ const mq_data = {
     "Ark Crisis": 210500000,
     "Coastal Clash": 216300000,
     "Unda's Rescue Operation": 222200000,
+    "Unda's Return": 228100000,
+    "The Young Man and The Old Tree": 234000000,
+    "The Village of Lixis": 240000000,
  };
 
 


### PR DESCRIPTION
Update xp calculator to latest main quest update (January 29, 2026):
- Add Episode 123: Unda's Return
- Add Episode 124: The Young Man and The Old Tree
- Add Episode 125: The Village of Lixis
- Update cap to level 315
- Update secondary stat count to 297